### PR TITLE
add option to redirect to separate page after successful registration

### DIFF
--- a/src/widgets/RegistrationPage.ts
+++ b/src/widgets/RegistrationPage.ts
@@ -132,6 +132,7 @@ export default class RegistrationPage extends RegistrationForm<RegistrationPageC
         self.templates.registrationPage.render(params);
       self.$root.html(content);
       self.successMessage = self.$root.find('#wsb-success');
+      self.successRedirectUrl = self.config.successRedirectUrl;
       self.successMessage.hide();
       self.form = self.$root.find('#wsb-form');
       self.assignEvents();

--- a/src/widgets/blocks/RegistrationForm.ts
+++ b/src/widgets/blocks/RegistrationForm.ts
@@ -18,6 +18,7 @@ export default abstract class RegistrationForm<T extends WidgetConfig> extends W
   protected formHelper: FormHelper;
   protected successMessage: JQuery<HTMLElement>;
   protected form: JQuery<HTMLElement>;
+  protected successRedirectUrl: string;
 
   /**
    * Creates a new registration form
@@ -68,8 +69,12 @@ export default abstract class RegistrationForm<T extends WidgetConfig> extends W
       transport.post(url, formData,
         (data: IPlainObject) => {
           self.formHelper.clearForm();
-          self.successMessage.show();
-          self.form.hide();
+          if (self.successRedirectUrl && self.successRedirectUrl !== '') {
+            window.location.href = self.successRedirectUrl;
+          } else {
+            self.successMessage.show();
+            self.form.hide();
+          }
           self.$root.removeClass('h-busy');
           $(e.target as HTMLElement).removeProp('disabled').removeClass('h-busy');
         });

--- a/src/widgets/config/RegistrationPageConfig.ts
+++ b/src/widgets/config/RegistrationPageConfig.ts
@@ -54,6 +54,11 @@ export default class RegistrationPageConfig extends WidgetConfig {
      */
     readonly countryDefault: string;
 
+    /**
+     * Redirect to successs page url instead of only showing success message
+     */
+    readonly successRedirectUrl: string;
+
     protected constructor(options: IPlainObject) {
         super(options);
         this.eventPageUrl = options.eventPageUrl ? options.eventPageUrl : undefined;
@@ -64,5 +69,6 @@ export default class RegistrationPageConfig extends WidgetConfig {
             this.countryOnlyFrom = options.country.onlyFrom !== undefined ? options.country.onlyFrom : undefined;
             this.countryDefault = options.country.default !== undefined ? options.country.default : undefined;
         }
+        this.successRedirectUrl = options.successRedirectUrl !== undefined ? options.successRedirectUrl : undefined;
     }
 }


### PR DESCRIPTION
For tracking purposes we would like to end on a separate page after successful registration. Therefore I added the possibility to redirect to a new page instead of just unhiding the success message.